### PR TITLE
Removed unnecessary ofstream

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(hunalign)
+
+set(NAME hunalign)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_FLAGS "-Wall -O9 -Ofast -ffast-math -funroll-loops")
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+set(sources hunalign/alignerTool.cpp hunalign/alignment.cpp hunalign/bloom.cpp hunalign/bookToMatrix.cpp hunalign/cooccurrence.cpp hunalign/cooccurrenceTool.cpp hunalign/dictionary.cpp hunalign/main.cpp hunalign/networkFlow.cpp hunalign/oldAlignTest.cpp hunalign/trailPostprocessors.cpp hunalign/translate.cpp hunalign/wordAlignment.cpp utils/stringsAndStreams.cpp utils/argumentsParser.cpp utils/timer.cpp)
+
+set(headers hunalign/alignment.h hunalign/bloom.h hunalign/bookToMatrix.h hunalign/cooccurrence.h hunalign/dictionary.h hunalign/dicTree.h hunalign/help.h hunalign/networkFlow.h hunalign/quasiDiagonal.h hunalign/similarityEvaluator.h hunalign/TEIReader.h hunalign/trailPostprocessors.h hunalign/translate.h hunalign/wordAlignment.h hunalign/words.h)
+
+add_library(hunalign_lib STATIC ${headers} ${sources})
+
+add_executable(hunalign hunalign/main.cpp)
+target_link_libraries(hunalign hunalign_lib)
+
+install(TARGETS hunalign DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/hunalign/translate.cpp
+++ b/src/hunalign/translate.cpp
@@ -237,10 +237,6 @@ void trivialTranslateSentenceList(
                            SentenceList& translatedSentenceList
                      )
 {
-  {
-    std::ofstream translateLogs( "translate.txt" );
-  }
-  
   translatedSentenceList.clear();
 
   for ( int i=0; i<sentenceList.size(); ++i )


### PR DESCRIPTION
The removed line seems to not be necessary. I have been testing removing it and everything went good, even modifying the `bool logging` to `true` in https://github.com/danielvarga/hunalign/blob/2fbcbc976495738321089e13cb728051350b84cd/src/hunalign/translate.cpp#L181

Until now, [Bitextor](https://github.com/bitextor/bitextor) have been using Hunalign for years from an own repository which contained the Hunalign release 1.2, but now that there is an official repo, we would like to use it directly instead. The problem is that the generated file `translated.txt` is always generated, even when `logging = false`, which is the default value. This file is not necessary when the logging is disabled, and it is not necessary since when the file is opened because `logging = true`, it is generated if does not exist (`std::ios::app` creates the file if does not exist). Doing this, we avoid to generate this file if it is not necessary, since if any other file with the same name exists, it will rewrite its content as I have tested that happens (the reason is that the default opening mode for `ofstream` is `std::ios::out`).